### PR TITLE
Feature/casmcms 8544

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/*
 /.project
 /.pydevproject
 /dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added rotating file handler to capture output for when syslog fails
+- Set connect and read timeout values for all connection objects using sessions
 
 ## [1.9.3] - 2023-06-22
 ### Added

--- a/src/cfs/client.py
+++ b/src/cfs/client.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/cfs/client.py
+++ b/src/cfs/client.py
@@ -71,6 +71,7 @@ def get_auth_token(path='/opt/cray/auth-utils/bin/get-auth-token'):
 
 def requests_retry_session(retries=10, connect=10, backoff_factor=0.5,
                            status_forcelist=(500, 502, 503, 504),
+                           connect_timeout=3, read_timeout=10,
                            session=None):
     session = session or requests.Session()
     retry = Retry(
@@ -79,6 +80,7 @@ def requests_retry_session(retries=10, connect=10, backoff_factor=0.5,
         connect=retries,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
+        timeout=(connect_timeout, read_timeout)
     )
     adapter = HTTPAdapter(max_retries=retry)
     session.mount(PROTOCOL, adapter)

--- a/src/cfs/status_reporter/__main__.py
+++ b/src/cfs/status_reporter/__main__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/cfs/status_reporter/__main__.py
+++ b/src/cfs/status_reporter/__main__.py
@@ -53,7 +53,7 @@ PROJECT_LOGGER.addHandler(_stream_handler)
 # will provide a backup mechanism to verify overall history of what was accomplished by the service on non-ephemerally
 # provisioned root filesystems.
 LOG_FILE_PATH = '/var/log/cfs_state_reporter.log'
-os.makedirs(os.path.dirname(LOG_FILE_PATH, exist_ok=True))
+os.makedirs(os.path.dirname(LOG_FILE_PATH), exist_ok=True)
 _rfh = logging.handlers.RotatingFileHandler(os.path.basename(LOG_FILE_PATH), maxBytes=1024*16, backupCount=2)
 _rfh.setLevel(LOG_LEVEL)
 PROJECT_LOGGER.addHandler(_rfh)


### PR DESCRIPTION
## Summary and Scope

This mod increases overall resilience of connections from the cfs-state-reporter service to timeout on connection and read loss. The overall effect is that these actions will be retried using the session level retry adapter instead of hanging indefinitely waiting on a read or connection that will never happen, or could happen, as a function of network hiccups.

This mod overhauls the logging setup to include an additional project root logger and attaches a rotatingfilehandler object to it to better allow debugging when syslog entries go missing.

## Issues and Related PRs

- Resolves CASMCMS-8544

## Testing

Tested on mug-m001 by installing the built RPM.


## Risks and Mitigations

Low risk, all gain.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

