### PR TITLE
CASMCMS-8770: List spire-agent as requirement for cfs-state-reporter RPM to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2023-08-22
+### Changed
+Updated `cfs-state-reporter` spec file to reflect the fact that it should not be installed without `spire-agent` being present.
+
 ## [1.10.0] - 2023-08-18
 ### Added
 - Added rotating file handler to capture output for when syslog fails

--- a/cfs-state-reporter.spec
+++ b/cfs-state-reporter.spec
@@ -34,6 +34,7 @@ Requires: python3-requests
 Requires: systemd
 Requires: cfs-trust
 Requires: cray-auth-utils
+Requires: spire-agent
 
 %define _systemdsvcdir /usr/lib/systemd/system
 


### PR DESCRIPTION
## Summary and Scope

`cfs-state-reporter` doesn't work without `spire-agent`. This PR just makes the requirement explicit.
