### PR TITLE
CASMTRIAGE-7663: Constrain requests_retry_session version to avoid requirements error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.1] - 2025-01-09
+### Fixed
+- Put upper limit on `requests_retry_session` RPM version to avoid requirements error
+
 ## [1.12.0] - 2024-08-21
 ### Changed
 - Changed how RPM release value is determined

--- a/cfs-state-reporter.spec
+++ b/cfs-state-reporter.spec
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@ Vendor: Cray Inc.
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 Requires: python3-base
 Requires: python3-requests
-Requires: python3-requests-retry-session >= 0.1.5
+Requires: python3-requests-retry-session >= 0.1.5, python3-requests-retry-session < 0.2.0
 Requires: systemd
 Requires: cfs-trust
 Requires: cray-auth-utils


### PR DESCRIPTION
On CSM 1.6.1, `cfs-state-reporter` hit an error because the version of `requests-retry-session` it was using required the `typing_extensions` Python module, which was not available on the system. That dependency was introduced in version 0.2 of `requests_retry_session`.

This PR modifies the `cfs-state-reporter` spec file to limit the `requests-retry-session` to less than 0.2, to ensure that this dependency problem is not hit.

I tested this on drax and verified that it worked.